### PR TITLE
Pyhash to mmh3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,1 @@
-pip install setuptools==57.5.0
 pip install --no-cache-dir -e .

--- a/lumos/datasets/base_dataset.py
+++ b/lumos/datasets/base_dataset.py
@@ -34,7 +34,7 @@ def get_validation_window_size(idx: int, min_window_size: int, max_window_size: 
     """
     window_range = max_window_size - min_window_size + 1
 
-    hash_val = mmh3.hash(str(idx)) & 0xFFFFFFFF  # ensure unsigned 32-bit
+    hash_val = mmh3.hash(str(idx), seed=0, signed=False)  # unsigned 32-bit
     return min_window_size + (hash_val % window_range)
 
 

--- a/lumos/datasets/base_dataset.py
+++ b/lumos/datasets/base_dataset.py
@@ -12,12 +12,11 @@ from lumos.datasets.utils.episode_utils import (
 )
 import numpy as np
 from omegaconf import DictConfig
-import pyhash
+import mmh3
 import torch
 from torch.utils.data import Dataset
 import copy
 
-hasher = pyhash.fnv1_32()
 logger = logging.getLogger(__name__)
 
 
@@ -34,7 +33,9 @@ def get_validation_window_size(idx: int, min_window_size: int, max_window_size: 
         Window size computed with hash function.
     """
     window_range = max_window_size - min_window_size + 1
-    return min_window_size + hasher(str(idx)) % window_range
+
+    hash_val = mmh3.hash(str(idx)) & 0xFFFFFFFF  # ensure unsigned 32-bit
+    return min_window_size + (hash_val % window_range)
 
 
 class BaseDataset(Dataset):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ matplotlib
 opencv-python
 tqdm
 wandb
-pyhash
+mmh3


### PR DESCRIPTION
Currently, we need to use an older version of setuptools (setuptools==57.5.0). From what I understand, this is because the PyHash library is not maintained and can't work with new setuptools versions. 

This PR:
1) Replaces the pyhash library with the [mmh3](https://pypi.org/project/mmh3/) library
2) Rewrites the get_validation_window_size function to use mmh3 instead of pyhash library
3) Removes the need to install an older setuptools version in the install.sh